### PR TITLE
Fix compiler error for non-void function not returning a value

### DIFF
--- a/sqlitepp.h
+++ b/sqlitepp.h
@@ -226,7 +226,7 @@ public:
   }
 
 private:
-  db& operator=(const db&) { }    // no assignment
+  db& operator=(const db&) = delete;    // no assignment
 
 private:
   ::sqlite3*        db_;    // associated db
@@ -467,7 +467,7 @@ public:
   }
 
 private:
-  transaction& operator=(const transaction&) { }    // no assignment
+  transaction& operator=(const transaction&) = delete;    // no assignment
 
 private:
   const db& db_;


### PR DESCRIPTION
I ran into trouble trying to use this library in Android Studio with the NDK. I got complaints about these two functions because they have non-null return values but the function implementations are empty. Explicitly marking the assignment operator as deleted fixes the compiler error.